### PR TITLE
chore: update gem sqlite3 gem version and allow active record >= v7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    metricks (1.0.1)
-      activerecord (>= 5.0, < 7.0)
+    metricks (1.0.2)
+      activerecord (>= 5.0)
       with_advisory_lock (>= 4.6, < 5.0)
 
 GEM
@@ -24,7 +24,8 @@ GEM
     diff-lcs (1.3)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.13.0)
+    mini_portile2 (2.8.2)
+    minitest (5.18.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -38,7 +39,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
-    sqlite3 (1.4.1)
+    sqlite3 (1.6.3)
+      mini_portile2 (~> 2.8.0)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -54,4 +56,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.0.2
+   2.4.13

--- a/metricks.gemspec
+++ b/metricks.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.authors       = ['Adam Cooke']
   s.email         = ['me@adamcooke.io']
-  s.add_runtime_dependency 'activerecord', '>= 5.0', '< 7.0'
+  s.add_runtime_dependency 'activerecord', '>= 5.0'
   s.add_runtime_dependency 'with_advisory_lock', '>= 4.6', '< 5.0'
 end


### PR DESCRIPTION
This allows active record v7 so metricks can work with rails v7. This also includes an upgrade to the sqlite3 gem version so it can work on m1 macs.