### PR TITLE
perf: improve query performance for Metric.latest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source 'https://rubygems.org'
 gemspec
+
+# Other dependencies are defined in the Appraisals file
 group :development do
   gem 'appraisal', '~> 2.4'
   gem 'rspec'
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.4'
 end

--- a/README.md
+++ b/README.md
@@ -227,3 +227,10 @@ compared_point.sum.percentage_change  # => The % change between 2019-01 and 2018
 # In addition to `sum`, there is also `count` and `last` as you expect from any
 # other point.
 ```
+
+## Run the tests
+
+To run the tests you can use the following commands from the [appraisal gem](https://github.com/thoughtbot/appraisal):
+
+- `bundle exec appraisal install`
+- `bundle exec appraisal rspec`

--- a/lib/metricks/models/metric.rb
+++ b/lib/metricks/models/metric.rb
@@ -67,7 +67,7 @@ module Metricks
         # @return [Float]
         def latest(type, **options)
           scope = self.last(type, **options)
-          value = scope.pluck(:amount)&.first || 0.0
+          value = scope.select(:amount).first&.amount || 0.0
           type.transform_amount(value, options[:associations])
         end
 


### PR DESCRIPTION
Currently it pulls all records from the database but only uses the most recent amount value.

This is inefficient, particularly if the database is large. Now it only retrieves the amount from the most recent record and ignores all the old ones.

I haven't added any tests because this method is already well covered and the underlying logic remains the same.